### PR TITLE
switch to using pyfsdb to parse a file rather than subprocess

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ marshmallow==3.7.1
 marshmallow-sqlalchemy==0.23.1
 prettyprint==0.1.5
 psycopg2cffi==2.9.0
+pyfsdb==2.4.2
 python-dateutil==2.8.1
 python-dotenv==0.13.0
 python-editor==1.0.4


### PR DESCRIPTION
The following patch removes the need to call an external process invoking `dbcol` and to use a python module for parsing directly.